### PR TITLE
Beautify the bot's messages #16 - fix

### DIFF
--- a/src/commands/whatsMyBirthday.js
+++ b/src/commands/whatsMyBirthday.js
@@ -18,12 +18,17 @@ module.exports = {
         
         let member = dbServer.members.find(m => m.user === message.author.tag)
         let embededMessage;
+
         if(member){
+            // Dates will all come back with the same character count so slicing up to the end of the year seems simplest
+            const formattedDate = member.birthday.toString().slice(0,15);
+            const randomColor = Math.floor(Math.random()*16777215).toString(16);
+            
             embededMessage = Util.embedMessage(
                 'Your Birthday',
                 message.author.tag,
-                '0xffff00',
-                `Your Birthday is set to ${member.birthday}.`                
+                `0x${randomColor}`,
+                `Your Birthday is set to ${formattedDate}.`                
             )
         }else{
             embededMessage = Util.embedMessage(


### PR DESCRIPTION
## For  issue #16 
Formatted the birthday text and made it more minimal, also added a color generator, and passed in the random color value for the embedded message color. Figured birthdays a multi-colored most of the time so why not. Let me know what you think @tomassirio 

![image](https://user-images.githubusercontent.com/40408940/96917454-8aa59e80-146e-11eb-9937-1fe687c20f02.png)
